### PR TITLE
Add Travis CI tests for node 0.9 and 0.10, add support for node 0.10 in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+  - 0.9
+  - 0.10
 
 notifications:
   email:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rig": "./bin/rig"
   },
   "engines": {
-    "node": ">= 0.6.x < 0.9.0"
+    "node": ">= 0.6.x < 0.11.0"
   },
   "dependencies": {
     "async": "0.2.x",


### PR DESCRIPTION
currently all tests are passing on Travis: https://travis-ci.org/adrianparsons/rigger
