### PR TITLE
Add mention of recursive import support to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ rig input.js > output.js
 
 ## Include All the Things
 
-Rigger supports a number of special include formats, and these are demonstrated in examples below.  While JS examples are provided, the formats will work in any of the known file formats.
+Rigger supports a number of special include formats, and these are demonstrated in examples below.  While JS examples are provided, the formats will work in any of the known file formats.  In addition, rigger supports recursive (nested) imports, so an imported file can have imports itself, and those imports can have imports, etc.
 
 ### Remote Resources
 


### PR DESCRIPTION
First off, THANK YOU for creating this library.  It's exactly what I've been looking for!

I just wanted to mention that you may want to mention that rigger does indeed support recursive imports in your readme, as that was a required feature for the current task I'm working on, and I had to go looking through your closed issues & commits to verify that it was indeed supported.  It's a small change, but could make the difference between someone adopting this library or not.
