### PR TITLE
Prevent rigged files from importing themselves

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ function Rigger(opts) {
 
     // initialise the basename from the opts
     this.basename = opts.basename;
+
+    // CHANGED: keep track of the file path being rigged to avoid self-inclusion
+    // initialize the file path from the opts
+    this.filepath = opts.filepath;
     
     // initialise the default file format
     this.filetype = formatters.normalizeExt(opts.filetype || 'js');
@@ -557,6 +561,9 @@ Rigger.prototype._getSingle = function(target, callback) {
                             Object.keys(converters).forEach(function(key) {
                                 valid = valid || key === (ext + '2' + rigger.filetype);
                             });
+
+                            // CHANGED: don't let a file import itself
+                            if (rigger.filepath && (path.join(realTarget, file) === rigger.filepath)) { valid = false; }
 
                             debug('found file: ' + file + ' + valid: ' + valid);
                             return valid;


### PR DESCRIPTION
add a check in the `_getSingle` method to compare a file being imported to
the file doing the importing.  If they match exactly, do not import it,
as the file would be importing itself.  This is an effort to fix #25 .
