### PR TITLE
Fix for using rigger with atom

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var regexes = require('buildjs.core/regexes');
 var formatters = require('buildjs.core/formatters');
 var platform = require('buildjs.core/platform');
 var _ = require('underscore');
+var allowUnsafeNewFunction = require('loophole').allowUnsafeNewFunction;
 
 // initialise the default converters
 var converters = {};
@@ -273,9 +274,11 @@ Rigger.prototype.include = function(match, settings, callback) {
 
   // initialise the target
   try {
-    target = _.template(templateText, {
-      interpolate : /\{\{(.+?)\}\}/g
-    })(settings);
+    target = allowUnsafeNewFunction(function() {
+      return _.template(templateText, {
+        interpolate : /\{\{(.+?)\}\}/g
+      })(settings);
+    });
   }
   catch (e) {
     return callback(new Error('Unable to expand variables in include "' + templateText + '"'));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "buildjs.core": "^1.0.0",
     "debug": "*",
     "getit": "^1.0.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "loophole": "~1.1.0"
   },
   "devDependencies": {
     "coffee-script": "1.9.3",


### PR DESCRIPTION
Hi. I'm using `rigger` in my Atom package. I'm getting error like `Refused to evaluate a string as JavaScript because 'unsafe-eval'....` when rigger uses `_.template()` method to build template.
[Here](https://discuss.atom.io/t/--template-causes-unsafe-eval-error/9310) solution which I found and implemented in this pr.